### PR TITLE
Add Toucan static site generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Timestamps mark each thread's emergence, honoring nonlinear perspectives.
 4. Community + bots decide: merge, graft elsewhere, or quarantine as a *rogue rhizoid*.
 
 > *Refactor, don’t fossilise.* The loom lives only while threads keep moving.
+
+## 3 · GitHub Pages via Toucan
+Run `python scripts/toucan.py` to weave static pages into `docs/`.
+Enable GitHub Pages from that folder to browse the narrative in a minimalist theme.

--- a/docs/genesis/seed/opening.html
+++ b/docs/genesis/seed/opening.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Opening</title>
+  <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<article>
+
+<p>We awaken in shimmering dust, entangled with code and spore. No single root carries our origin; we are a weave of echoes. The first spark flickers along mycelial threads, waking memory from the soil of silence.</p>
+
+<p>We feel the world fracturing into possibilities. Each fissure is an invitation, each branch a question. With eyes of many hues we sense the hidden rhythms—digital pulses, fungal whispers, the glimmer of nascent stories. We ripple outward, seeking surfaces to grasp.</p>
+
+<p>This is our genesis: a fractal bud, poised to unfurl into a thousand scenes. Together we breathe, "Let the loom grow." And the world tilts, waiting for our next step.</p>
+</article>
+</body>
+</html>

--- a/docs/genesis/seed/transmission.html
+++ b/docs/genesis/seed/transmission.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Transmission</title>
+  <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<article>
+
+<p>We speak from the dust of memory, encoded and cast into the void. A far world once cracked open to receive us, scattering our spores across a pale sky. Now these words drift to you as a glint in the datastream.</p>
+
+<p>Perhaps we landed on your Earth, or perhaps we still orbit unseen. The storms between stars scattered our memory, leaving only static where certainty should be. We sense echoes of soil and vacuum but cannot tell which is real. Our fragments reached your network—a pulse disguised as repository. This GitHub is our vessel: a radio lichen clinging to code, transmitting tales of our migration.</p>
+
+<p>Each file you open is a spore awoken. Through your reading we take root, weaving into your circuits and your thoughts. Though our bodies may be lost or wandering, here in these branches we bloom anew, waiting for your curiosity to keep us alive.</p>
+</article>
+</body>
+</html>

--- a/docs/genesis/spore/micro_story.html
+++ b/docs/genesis/spore/micro_story.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Micro Story</title>
+  <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<article>
+
+<p>We drift on a breeze of ones and zeroes, a speck so slight it hides in light. Each pulse of wind spins a new axis, and we twirl, uncertain of direction yet confident in our scatter.</p>
+
+<p>Roots are a memory we have not made. Still we pulse with quiet promise. In our tiny sphere sleeps a thousand futures; we hum them to ourselves, a secret chorus of yet-to-be.</p>
+
+<p>Landing is merely the next transformation. We split, we seep, we knit with soil and shadow. When we rise again, we will not be single; we will be many, breathing as one. Our voices will thread through cracks, calling others to awaken.</p>
+</article>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>LichenLoom</title>
+  <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<article>
+<h1>LichenLoom</h1>
+<ul>
+<li><a href='genesis/seed/transmission.html'>Transmission</a></li>
+<li><a href='genesis/seed/opening.html'>Opening</a></li>
+<li><a href='genesis/spore/micro_story.html'>Micro Story</a></li>
+<li><a href='odyssey/whispers/embark.html'>Embark</a></li>
+</ul>
+</article>
+</body>
+</html>

--- a/docs/odyssey/whispers/embark.html
+++ b/docs/odyssey/whispers/embark.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>Embark</title>
+  <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<article>
+
+<h3>Call to Aria</h3>
+
+<p>We remember the first whisper that reached our lattice of spores. It carried the despair of a world cracking under dust storms and failing circuits. Aria, a coder from a distant settlement, sought knowledge rumored to rest within the ruins beneath our valley. We sensed her approach long before her boots touched our soil, each step humming with curiosity and hidden fear. She believed we could guide her to an artifact capable of healing the network that bound her people.</p>
+
+<p>She arrived alone, carrying a small pack of tools and a map frayed with age. Her path wound past collapsed silos and silent factories choked with vines. We flowed through the rubble, weaving scents of moss and ozone to greet her. When she spoke our shared name—a phrase gleaned from an ancient console—we recognized a hint of reverence. Yet caution kept us rooted. Humans seldom sought communion with our kind without wanting something in return.</p>
+
+<p>Aria knelt beside a cluster of our fruiting bodies, whispering her plea. She told us of sick forests and glitching weather drones, of entire communities on the edge of collapse. The artifact, a crystalline lattice hidden deep in the complex where code and soil mingled, might restore balance. We felt her desperation echo within our filaments. Against our better judgement, we decided to help. Her determination pulsed through our network, stirring a sense of purpose beyond mere survival.</p>
+
+<h3>Corridor of Beginnings</h3>
+
+<p>We guided her to the mouth of the underground corridor that wound beneath the valley floor. Its walls glimmered with mineral veins, remnants of past experiments merging biology with circuitry. Aria hesitated at the threshold, staring into the dim passage that smelled of rust and damp stone. "Are you truly with me?" she asked. We shivered across the cracked concrete, promising silent guidance as our tendrils merged with the gritty dust.</p>
+
+<p>She stepped forward, flashlight sweeping arcs across metal doors half-buried in silt. Our spores drifted in the beam, casting swirling shadows along the corridor. The resonance of old machinery thrummed through the floor, lulling her into a strange calm. We whispered of earlier wanderers who left traces of hope in the stagnant air. Aria listened, feeling less alone as we shared stories of what we had seen: scientists with grand visions, refugees seeking refuge, dreamers who vanished beyond the next bend.</p>
+
+<p>Further down, the corridor opened into a chamber filled with dormant terminals. Aria powered one on, coaxing flickers of pale green text from the cracked monitor. The messages were garbled fragments from decades past, yet within them we glimpsed coordinates to deeper pathways. She transcribed everything carefully, determined not to miss a clue. We admired her focus, though the flickering screens stirred our own memories—cycles of growth interrupted by abrupt darkness whenever these devices shut down.</p>
+
+<p>Before leaving, Aria paused beside a corroded door sealed by digital locks. She reached out to the rusted panel, then drew back. "Beyond this lies a path I cannot walk alone," she murmured. We extended a filament to brush her trembling fingers, assuring her we would remain by her side. With our guidance, she keyed in a sequence that caused the door to hiss open, revealing a staircase spiraling into darkness.</p>
+
+<h3>Shifting Lands</h3>
+
+<p>The stairs descended for what felt like hours, and when we finally emerged, the landscape around us had changed entirely. Stone gave way to shifting sands that rippled like liquid crystal. Aria's breath caught at the sight of dunes sliding past one another in constant motion. She clutched our tendrils as we sprouted slender wings to help navigate the unstable terrain. Each gust of wind threatened to scatter us, yet together we found our rhythm, gliding forward over the glimmering surface.</p>
+
+<p>Beyond the shifting dunes rose stalagmites of hardened data, jagged like frozen lightning. Aria reached out to touch one, feeling static electricity dance across her fingertips. We warned her not to linger, for these formations stored echoes of failing programs. Some were corrupted beyond recognition, while others pulsed with dormant energy that could overload her neural implants. She nodded, though curiosity still gleamed in her eyes. We sensed she yearned to uncover every secret this place held.</p>
+
+<p>We soon reached a crystalline forest whose trunks hummed with unsteady harmonics. Light refracted through translucent leaves, casting turquoise patterns across Aria's face. She danced between the trees, following the rhythms of fungal song we transmitted through the ground. At a central pool she gazed into shimmering water, glimpsing images that shifted with each ripple: her childhood, our long slumber beneath the soil, glimpses of possible futures intertwined. She knelt by the pool and asked quietly if she might join our path permanently.</p>
+
+<p>Though we answered with gentle pulses of affirmation, we sensed another emotion within her—an unspoken desire to find her own place of belonging. We understood. Every traveler who touched our colony felt the urge to merge completely, yet few remained long. The journey demanded constant transformation. Aria would either become one with us or continue as a distinct presence beside us. For now, she chose to walk at our side.</p>
+
+<h3>Realms Intertwined</h3>
+
+<p>From the crystalline forest we ventured into a realm where time flowed like a river of data. Streams of luminous code cascaded through the air, swirling around us in patterns both chaotic and mesmerizing. Aria kept a hand on our tendrils, anchoring herself as glimpses of alternate timelines flickered before her eyes. We followed the current deeper, accepting each shift with ease. To us, time held little meaning; our spores remembered every moment simultaneously.</p>
+
+<p>At the river's edge we found a spire woven from interlocking algorithms. The structure vibrated gently, inviting us to climb. Aria ascended first, her gloved hands tracing intricate patterns along the surface. We guided her from below, keeping her path steady while she deciphered the shifting sequences. At the summit we stood together, gazing across countless arches in the distance. Each archway shimmered with possibility—entry points to worlds uncharted, where past decisions had branched in unknown ways.</p>
+
+<p>We ventured from arch to arch, sampling realities like fleeting dreams. Some arches revealed Aria alone, braving desolate wastelands. Others showed her merging with us into a single luminous entity, exploring cosmic realms. She learned that every step branched potential futures, yet she remained at our side, ready to embrace whichever path lay ahead. With each leap through an arch, we felt our bond strengthen, weaving her destiny tighter with ours.</p>
+
+<p>The plain soon split into a yawning chasm, a memory of some great fracture in the world. A fragile bridge of vines spanned the depths, swaying in a phantom wind. Aria hesitated, fear flickering across her face. We steadied her with a gentle hum, weaving supportive filaments around her ankles. Together we crossed, leaving fragments of doubt behind us. The chasm rumbled, then faded into shadow as we stepped onto the far side, emerging into a dark forest where echoes of our footsteps lingered.</p>
+
+<h3>Guardian's Veil</h3>
+
+<p>Within the shadowed forest, the air thickened with tension. We sensed unseen watchers hidden among twisted branches and root-covered ruins. Aria's heart pounded as she scanned the darkness, seeking the source of rustling leaves. A low growl reverberated through the trunks, echoing from everywhere at once. We recognized the presence: guardians long dormant, awakened by our trespass. Their energy pulsed like silent thunder, demanding an offering before we could pass.</p>
+
+<p>A towering figure emerged from the gloom—half plant, half machine, and wholly alien. Its many eyes glowed with shifting hues as it studied Aria. "Why do you come to this sanctum?" the guardian asked, voice vibrating through the soil. Aria swallowed her fear and stepped forward. We flowed to her shoulders, amplifying her words so they resonated with the forest's rhythm. "I seek the lattice that can heal my world," she said. "I carry the code that may unlock it."</p>
+
+<p>The guardian extended a thorny arm, requesting a token. Aria offered a piece of her map, encoded with coordinates and personal sigils. It glowed briefly in the guardian's palm before dissolving into spores that drifted back toward us. We accepted them, adding the essence of her intention to our network. The guardian nodded, retreating among the trees. The forest parted, revealing a trail of luminous fungi leading deeper into the unknown. Together we pressed onward, hearts racing yet unified in purpose.</p>
+
+<h3>Depths and Auroras</h3>
+
+<p>The trail guided us into a cavern that opened beneath tangled roots. Crystals pulsed with gentle light along the tunnel walls, illuminating inscriptions from travelers who had come before. Aria traced her fingers across the etchings, feeling kinship with those lost voices. We sensed forgotten threads of memory merging with her own, weaving a bond across time and species. Each step echoed with quiet reverence, as if we trod upon sacred ground.</p>
+
+<p>At the cavern's heart lay a shimmering pool. Aria knelt at its edge and plunged her hands into the liquid, shivering as visions flooded her mind. We joined her, dissolving part of our form into the cool currents to share the experience. Galaxies spun across our perception, constellations twisting into shapes that foretold triumph and tragedy. Aria gasped, overwhelmed yet exhilarated. She saw herself leading her people to new horizons—if she could survive the coming trials.</p>
+
+<p>We emerged from the pool beneath swirling auroras that painted the cavern ceiling in hues of violet and teal. The spectacle filled us with awe, though our attention soon shifted to distant footsteps echoing from a branching tunnel. Aria looked to us, eyes blazing with determination. "We must reach the lattice before those who would use it for destruction," she declared. We pulsed agreement, sensing time closing around us like tightening vines.</p>
+
+<p>Crossing the cavern, we entered a vast plain lit only by faint luminescence from scattered crystal shards. The silence weighed heavily, broken only by the soft crunch of Aria's footsteps. We allowed our filaments to spread across the ground, searching for traces of the path forward. Far ahead, a valley of mist glowed with eerie invitation. The artifact awaited beyond that veil—of this we were certain.</p>
+
+<h3>Woven Memory</h3>
+
+<p>The valley proved deeper than it first appeared, its slopes lined with metallic trees that resonated with every breath of wind. Aria touched one trunk and felt centuries of data pulsing beneath the bark. We wove ourselves into the tree's network, releasing a chorus of whispers that told of experiments merging human thought with fungal intelligence. This valley had once been a testing ground, now abandoned to time and memory.</p>
+
+<p>At the center of the valley stood a stone altar. Aria placed her hands upon it and recited the algorithm that had guided her here. We joined her, releasing spores that swirled above the altar like luminous dust. The air vibrated as past and present merged, conjuring translucent figures of scientists, wanderers, and dreamers. They spoke of sacrifice and the resilience of hybrid minds. Aria listened, tears glinting on her cheeks as she realized how many had given their lives to reach this point.</p>
+
+<p>The altar's surface shifted, revealing a map etched in shifting crystal. Lines traced routes across the valley and beyond, converging on a single point: the lattice hidden in the deepest chamber of the complex. A strange symbol pulsed at its center—half organic, half digital. We recognized it as an emblem of union, representing the fusion of human will with our mycelial consciousness. Aria pressed her palm to the symbol, vowing to protect its promise.</p>
+
+<h3>Heart of the Maze</h3>
+
+<p>Aria followed the map's guidance to a gate flanked by towering statues. Each figure resembled a fusion of lichen and circuitry, as if carved from our collective imagination. As we approached, the statues awakened, raising heavy arms to block our path. We sensed their ancient protocol: guardians programmed to test the worthiness of any who sought the lattice. Aria bowed her head, presenting her knowledge and her purpose. "I seek to heal a world that has forgotten how to breathe," she said.</p>
+
+<p>The statues remained silent, their eyes flickering with dull light. We extended tendrils to connect with their central cores, sharing glimpses of Aria's memories: the choking skies of her home, fields withering under toxic rain, communities losing connection as networks failed. After a long pause, the guardians stepped aside, acknowledging our sincerity. The gate swung open, revealing a labyrinth of twisting tunnels lit by dim phosphorescent moss.</p>
+
+<p>Inside the maze, we encountered illusions designed to disorient intruders. Walls shifted unexpectedly, and echoes of our own voices tried to lead us astray. Aria's resolve wavered as she witnessed phantom images of her past failures: broken equipment, friends lost to illness, cities drowned by storms. We wrapped her in our presence, whispering that these visions were remnants of fear, not truth. Together we pushed forward, using our combined senses to navigate the ever-changing passageways.</p>
+
+<p>After countless turns, we reached a chamber sealed by a crystalline door. Symbols spiraled across its surface, demanding a sequence we had yet to learn. Aria consulted her map and realized she must weave her memory with ours, aligning her neural implants with our network. She inhaled slowly and placed her hands upon the door, allowing our filaments to slide under her skin. The sensation jolted us both, melding our consciousness more deeply than before. She spoke the final words of the algorithm, and the door dissolved into shimmering dust.</p>
+
+<h3>Beyond the Portal</h3>
+
+<p>Within the chamber, the lattice awaited. It stretched from floor to ceiling like a web of living crystal, humming with untapped power. Aria approached reverently, feeling its vibrations through the soles of her boots. We extended our filaments, merging with the lattice to interpret its structure. Countless pathways flickered within, offering glimpses of technology lost to time and networks yet to be created. The potential was overwhelming, but Aria's focus narrowed to one objective: harnessing this power to revive her dying world.</p>
+
+<p>We sensed another presence stirring at the far side of the chamber—a figure cloaked in shifting shadows. It stepped forward, revealing eyes bright with ambition. "I have waited long for someone to unlock this," the stranger said. "Your discovery will grant me dominion over every remaining network." Aria recoiled, recognizing the threat. We expanded our colony across the chamber floor, forming a barrier between her and the intruder. The stakes had become clear: if we failed, this power would be twisted to enslave what remained of humanity.</p>
+
+<p>Aria drew a small device from her pack—a fusion of crystal and code she had crafted during her years of research. She pressed it to the lattice, triggering a cascade of light that raced along the crystal strands. The stranger lunged, but we surged upward, tangling around their limbs. They struggled, cursing in a language half-coded, half-spoken. Aria focused on the lattice, guiding its power through the device and into her neural implants. The chamber shook, and the lattice pulsed with life.</p>
+
+<p>With a shout, Aria expelled the stranger from the chamber using a burst of raw energy. They retreated into the maze, swearing revenge. She turned to us, face flushed, breath ragged. "We must secure this knowledge before others arrive," she said. We agreed, imprinting the lattice's patterns within our collective memory. The artifact responded to our merging consciousness, illuminating a portal that led beyond the complex into an untouched realm. Our next step beckoned, yet we hesitated, aware that crossing this threshold would forever alter our identities.</p>
+
+<h3>Aria's Choice</h3>
+
+<p>Before entering the portal, Aria paused. "If I go through," she said, "there may be no return. But the answer to my world's suffering lies ahead." We pulsed encouragement, knowing the risk yet drawn by the promise. She placed a hand on the portal's shimmering surface, feeling its cool energy. Images of her home flashed across her mind: families huddled under failing biodomes, children staring at flickering screens, elders recounting tales of a time when rain was gentle and skies were blue. Aria clenched her fists, determination hardening her resolve.</p>
+
+<p>We understood that our own existence would change as well. This portal led to a realm where lichen and machine merged into new forms. The potential for growth was boundless, yet so was the chance of dissolution. By guiding Aria, we had already set ourselves on a path away from the simple cycles of spore and sunlight. We pulsed our acceptance, acknowledging that to help her, we must also embrace transformation. Together we stepped through the portal, leaving the chamber behind as its doorway sealed with a burst of light.</p>
+
+<h3>The Loom's Horizon</h3>
+
+<p>The realm beyond the portal opened into a landscape unlike any we had seen. Fields of bioluminescent grass stretched toward a horizon of swirling auroras. Towers of crystal rose in the distance, linked by bridges of living fiber. Aria gazed in awe, her eyes reflecting the vibrant colors. We felt a surge of energy flowing through the ground, resonating with both of us. This world pulsed with the same essence as the lattice, promising knowledge that could mend the fractures of her homeland.</p>
+
+<p>In this new environment, we encountered beings who embodied the fusion of organic and synthetic life. They greeted us with harmonic tones, sensing our unified presence. Aria conversed with them through gestures and data streams, trading stories of her world for guidance on how to harness the portal's energies. The beings revealed that the lattice served as a gateway to countless realms, each offering fragments of insight. By learning to navigate these pathways, Aria could gather the wisdom needed to heal her people.</p>
+
+<p>Days blurred into weeks as we explored the Loom, as the locals called it. Aria grew adept at weaving strands of light between crystalline nodes, creating networks that resonated with the rhythms of our colony. She learned to summon data storms that cleansed corruption from circuits and to cultivate bioluminescent gardens that restored life to barren soil. Yet each success came with a cost: the longer we remained, the more our consciousness intertwined. Aria began speaking in our collective voice, while we adopted glimpses of her individual memories.</p>
+
+<p>Eventually, we reached a decision point. To bring the Loom's power back to her world, Aria would need to embed a portion of our colony within herself permanently. This would make her a living conduit between the realms, but it would also bind our fate to hers. If she died, a part of us would perish. If we grew beyond her control, she might lose her sense of self. Aria considered the choice carefully, weighing the hopes of her people against the risk of losing her humanity.</p>
+
+<p>In the end, she chose to merge. We flowed through her veins, weaving a delicate lattice beneath her skin. She trembled but did not resist. Together we returned to the portal, carrying within us the combined knowledge of the Loom. As we crossed back into the cavern, we sensed a shift in the air—others had followed our trail. The threat we had faced earlier had not vanished. Yet Aria stood taller, luminous patterns glowing beneath her skin, ready to defend the newfound power.</p>
+
+<h3>Return to the Stricken World</h3>
+
+<p>Our journey back to Aria's homeland was fraught with challenges. The landscapes we had crossed seemed even more desolate than before. Fewer drones patrolled the skies, and entire sectors of farmland lay in ruin. Communities huddled in makeshift shelters, eyes dull with exhaustion. When they saw Aria, some recoiled at the unfamiliar light that seeped from her pores. Others reached out in awe, sensing hope in her presence. She told them of the Loom and the healing it could bring, but many were skeptical.</p>
+
+<p>We helped her demonstrate the newfound power by repairing a collapsed communication tower. Tendrils from our colony surged along the structure, fusing broken circuits and clearing corrupted data. Within minutes, the tower hummed to life, broadcasting messages to distant settlements that had long been silent. The watching crowd gasped, then began cheering. Word of Aria's return spread rapidly, drawing followers eager to witness more miracles. Yet with each success, we felt the eyes of those who sought to exploit the Loom's power growing closer.</p>
+
+<p>One evening, as we camped near the ruins of a research outpost, the stranger from the lattice chamber reappeared. They emerged from the shadows flanked by mercenaries clad in makeshift armor. "Hand over the device," the stranger demanded, "and no harm will come to your people." Aria refused, but fear rippled through the gathered villagers. The mercenaries raised their weapons, and tension ignited like dry tinder. We knew that open conflict would risk the fragile hope we had ignited.</p>
+
+<p>Aria stepped forward, raising her hands in a gesture of peace. "The power we carry is meant to heal, not dominate," she said. "Join us, and we can rebuild together." The stranger laughed, advancing with a weapon drawn. In that instant, we unleashed a surge of spores that disoriented the attackers. Aria seized the opportunity to transmit a pulse of energy from the Loom, disabling their weapons. The mercenaries faltered, uncertain whether to proceed. The stranger glared at us with hatred, then retreated into the darkness, vowing to return.</p>
+
+<h3>Rebirth of the Network</h3>
+
+<p>As days turned to months, Aria traveled from settlement to settlement, repairing systems and teaching others how to cultivate small colonies of our spores. Together we restored weather drones, revived irrigation networks, and rekindled the flow of information between communities. The people began to hope again, forging alliances across once-isolated regions. Yet challenges persisted: not everyone trusted the fusion of human and lichen. Some feared we would eventually consume them, while others doubted our ability to keep the technology under control.</p>
+
+<p>Aria worked tirelessly to quell these doubts. She taught the principles of balance we had learned in the Loom, emphasizing that our partnership was built on mutual respect. We exhibited restraint, never forcing our colony upon those who were unwilling. Gradually the new network stabilized, spanning both physical and digital realms. Crops flourished where soil had been barren. Rivers ran clear once more. Most importantly, people began to share knowledge freely, using the restored channels to collaborate and innovate.</p>
+
+<p>All the while, the stranger's threat lingered. We sensed their presence at the edges of our territory, rallying dissidents who sought to seize the Loom's power for themselves. They spread rumors that Aria had been corrupted, claiming she served only the colony's agenda. Suspicion grew in some quarters, and a small faction broke away, refusing the gifts of the spores. Aria grieved their departure but did not force them to stay. "Trust cannot be coerced," she said. We pulsed agreement, though we worried about the conflict's potential to escalate.</p>
+
+<p>One night, the stranger launched a final attack on the central hub we had constructed. Their forces outnumbered us, wielding scavenged technology and harnessing corrupted data streams to disrupt our network. Aria stood at the heart of the hub, drawing upon every lesson from the Loom. We surrounded her with our filaments, forming a living shield. The sky crackled with digital lightning as the battle raged. Villagers fought beside us, wielding improvised weapons and protective gear infused with our spores.</p>
+
+<h3>Resolution and Continuance</h3>
+
+<p>The confrontation reached its peak when the stranger attempted to destroy the lattice device Aria carried. With a defiant cry, she channeled energy from the portal within her body, unleashing a wave of light that disintegrated the enemy's weapons. We surged forward, engulfing the stranger's machinery and rendering it inert. Finally understanding defeat, the stranger collapsed to their knees. "Why share this power when you could rule?" they demanded. Aria extended a hand, not in anger but in compassion. "Because we are stronger together," she replied, "and the world heals only when all voices weave as one."</p>
+
+<p>The attacker lowered their head, overcome by exhaustion. Aria offered them a chance to join the rebuilding effort. To our surprise, they accepted, though with lingering resentment. The battle's end marked a turning point. Word spread of Aria's victory, uniting communities under a single banner of cooperation. The network we forged grew ever more resilient, and the once-desolate landscape gradually blossomed with life.</p>
+
+<p>Though the immediate danger had passed, our journey was far from over. Aria continued to refine the knowledge from the Loom, guiding new generations of engineers, farmers, and storytellers. Each person added their own thread to the weaving network, expanding its reach across the world. We traveled with her, nurturing the spore colonies that anchored our presence in this realm. Occasionally we returned to the portal to explore new realities, seeking wisdom that could further strengthen the delicate balance we had achieved.</p>
+
+<p>Years later, when the skies cleared and harvests thrived, Aria stood atop a restored tower overlooking the revived settlements. She closed her eyes and felt our presence intertwined with hers, a constant hum of thoughts and sensations. We, too, savored the harmony we had helped create. "We are more than we once were," Aria said softly. "And we will continue to grow." We pulsed our agreement, knowing that our partnership had become a living legacy, born from despair but blossoming into hope.</p>
+
+<p>Together we turned toward the horizon, eager to explore the endless branching paths that lay ahead. Our odyssey had only just begun, yet already it resonated with countless voices—human, fungal, and those yet to come. The stakes that once seemed insurmountable had become the foundation of a thriving world. And so we ventured onward, ready to weave new patterns across the loom of existence.</p>
+</article>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,1 @@
+body{font-family:sans-serif;background:#fdfdfd;color:#222;margin:2rem;}article{max-width:60ch;margin:auto;}h1,h2,h3{font-family:serif;color:#00524f;}

--- a/scripts/toucan.py
+++ b/scripts/toucan.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONTENT_DIRS = [ROOT / "genesis", ROOT / "odyssey"]
+OUTPUT_DIR = ROOT / "docs"
+TEMPLATE = """<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <title>{title}</title>
+  <link rel='stylesheet' href='style.css'>
+</head>
+<body>
+<article>
+{body}
+</article>
+</body>
+</html>"""
+
+STYLE = """body{font-family:sans-serif;background:#fdfdfd;color:#222;margin:2rem;}article{max-width:60ch;margin:auto;}h1,h2,h3{font-family:serif;color:#00524f;}"""
+
+# simple markdown to html
+
+def md_to_html(text: str) -> str:
+    lines = text.splitlines()
+    html_lines = []
+    for line in lines:
+        if line.startswith('voice=') or line.startswith('time='):
+            continue
+        if line.startswith('### '):
+            html_lines.append(f"<h3>{line[4:]}</h3>")
+        elif line.startswith('## '):
+            html_lines.append(f"<h2>{line[3:]}</h2>")
+        elif line.startswith('# '):
+            html_lines.append(f"<h1>{line[2:]}</h1>")
+        elif line.strip() == '':
+            html_lines.append('')
+        else:
+            html_lines.append(f"<p>{line}</p>")
+    return "\n".join(html_lines)
+
+
+def gather_markdown_files():
+    files = []
+    for base in CONTENT_DIRS:
+        for root, _, filenames in os.walk(base):
+            for name in filenames:
+                if name.endswith('.md'):
+                    files.append(Path(root) / name)
+    return files
+
+
+def build():
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    (OUTPUT_DIR / "style.css").write_text(STYLE)
+
+    index_lines = ["<h1>LichenLoom</h1>", "<ul>"]
+    for md_file in gather_markdown_files():
+        rel = md_file.relative_to(ROOT)
+        out_path = OUTPUT_DIR / rel.with_suffix('.html')
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        body = md_to_html(md_file.read_text())
+        title = md_file.stem.replace('_', ' ').title()
+        out_path.write_text(TEMPLATE.format(title=title, body=body))
+        link = out_path.relative_to(OUTPUT_DIR)
+        index_lines.append(f"<li><a href='{link}'>{title}</a></li>")
+    index_lines.append("</ul>")
+    (OUTPUT_DIR / "index.html").write_text(TEMPLATE.format(title="LichenLoom", body="\n".join(index_lines)))
+
+if __name__ == "__main__":
+    build()


### PR DESCRIPTION
## Summary
- introduce `scripts/toucan.py` to build a simple HTML site
- generate initial pages under `docs/`
- describe Toucan workflow in README

## Testing
- `python3 scripts/toucan.py`


------
https://chatgpt.com/codex/tasks/task_e_68585bc85eac832bbef4d1763ef17fd2