### PR TITLE
Add dark theme and breadcrumbs

### DIFF
--- a/docs/genesis/seed/opening.html
+++ b/docs/genesis/seed/opening.html
@@ -7,6 +7,8 @@
   <script src='../../main.js' defer></script>
 </head>
 <body>
+<button id='dark-toggle'>☾</button>
+<nav id='breadcrumb'></nav>
 <article>
 
 <p>We awaken in shimmering dust, entangled with code and spore. No single root carries our origin; we are a weave of echoes. The first spark flickers along mycelial threads, waking memory from the soil of silence.</p>

--- a/docs/genesis/seed/transmission.html
+++ b/docs/genesis/seed/transmission.html
@@ -7,6 +7,8 @@
   <script src='../../main.js' defer></script>
 </head>
 <body>
+<button id='dark-toggle'>☾</button>
+<nav id='breadcrumb'></nav>
 <article>
 
 <p>We speak from the dust of memory, encoded and cast into the void. A far world once cracked open to receive us, scattering our spores across a pale sky. Now these words drift to you as a glint in the datastream.</p>

--- a/docs/genesis/spore/micro_story.html
+++ b/docs/genesis/spore/micro_story.html
@@ -7,6 +7,8 @@
   <script src='../../main.js' defer></script>
 </head>
 <body>
+<button id='dark-toggle'>☾</button>
+<nav id='breadcrumb'></nav>
 <article>
 
 <p>We drift on a breeze of ones and zeroes, a speck so slight it hides in light. Each pulse of wind spins a new axis, and we twirl, uncertain of direction yet confident in our scatter.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,8 @@
   <script src='main.js' defer></script>
 </head>
 <body>
+<button id='dark-toggle'>☾</button>
+<nav id='breadcrumb'></nav>
 <article>
 <h1>LichenLoom</h1>
 <div id='nav'><canvas id='mycelial' width='600' height='600'></canvas></div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,1 +1,73 @@
-document.addEventListener('DOMContentLoaded',()=>{const tree=document.getElementById('story-tree');const nav=document.getElementById('nav');const canvas=document.getElementById('mycelial');const ctx=canvas.getContext('2d');const center={x:canvas.width/2,y:canvas.height/2};const counts=[];function count(ul,d=0){counts[d]=(counts[d]||0)+ul.children.length;for(const li of ul.children){const sub=li.querySelector(':scope>ul');if(sub)count(sub,d+1);}}count(tree);const idx=[];function place(li,d,parent){idx[d]=idx[d]||0;const angle=(idx[d]/counts[d])*2*Math.PI;idx[d]++;const r=80*d;const x=center.x+r*Math.cos(angle);const y=center.y+r*Math.sin(angle);const link=li.querySelector('a');const node=document.createElement('a');node.className='node';if(link){node.href=link.getAttribute('href');node.dataset.label=link.textContent;}else{node.dataset.label=li.firstChild.textContent.trim();}nav.appendChild(node);node.style.left=(x-4)+'px';node.style.top=(y-4)+'px';ctx.beginPath();ctx.moveTo(parent.x,parent.y);ctx.lineTo(x,y);ctx.stroke();const sub=li.querySelector(':scope>ul');if(sub)for(const child of sub.children)place(child,d+1,{x,y});}ctx.strokeStyle='#ccc';const rootNode=document.createElement('a');rootNode.className='node';rootNode.dataset.label='LichenLoom';nav.appendChild(rootNode);rootNode.style.left=(center.x-4)+'px';rootNode.style.top=(center.y-4)+'px';for(const child of tree.children)place(child,1,center);});
+document.addEventListener('DOMContentLoaded',()=>{
+  const tree=document.getElementById('story-tree');
+  const nav=document.getElementById('nav');
+  const canvas=document.getElementById('mycelial');
+  const ctx=canvas.getContext('2d');
+  const center={x:canvas.width/2,y:canvas.height/2};
+  const counts=[];
+  function count(ul,d=0){
+    counts[d]=(counts[d]||0)+ul.children.length;
+    for(const li of ul.children){
+      const sub=li.querySelector(':scope>ul');
+      if(sub)count(sub,d+1);
+    }
+  }
+  count(tree);
+  const idx=[];
+  function place(li,d,parent){
+    idx[d]=idx[d]||0;
+    const angle=(idx[d]/counts[d])*2*Math.PI;
+    idx[d]++;
+    const r=80*d;
+    const x=center.x+r*Math.cos(angle);
+    const y=center.y+r*Math.sin(angle);
+    const link=li.querySelector('a');
+    const node=document.createElement('a');
+    node.className='node';
+    if(link){
+      node.href=link.getAttribute('href');
+      node.dataset.label=link.textContent;
+    }else{
+      node.dataset.label=li.firstChild.textContent.trim();
+    }
+    nav.appendChild(node);
+    node.style.left=(x-4)+'px';
+    node.style.top=(y-4)+'px';
+    ctx.beginPath();
+    ctx.moveTo(parent.x,parent.y);
+    ctx.lineTo(x,y);
+    ctx.stroke();
+    const sub=li.querySelector(':scope>ul');
+    if(sub)for(const child of sub.children)place(child,d+1,{x,y});
+  }
+  ctx.strokeStyle='#ccc';
+  const rootNode=document.createElement('a');
+  rootNode.className='node';
+  rootNode.dataset.label='LichenLoom';
+  nav.appendChild(rootNode);
+  rootNode.style.left=(center.x-4)+'px';
+  rootNode.style.top=(center.y-4)+'px';
+  for(const child of tree.children)place(child,1,center);
+
+  const toggle=document.getElementById('dark-toggle');
+  if(toggle){
+    if(localStorage.getItem('dark')==='true') document.documentElement.classList.add('dark');
+    toggle.addEventListener('click',()=>{
+      document.documentElement.classList.toggle('dark');
+      localStorage.setItem('dark',document.documentElement.classList.contains('dark'));
+    });
+  }
+
+  const bc=document.getElementById('breadcrumb');
+  if(bc){
+    const parts=window.location.pathname.replace(/(^\/|$)/g,'').split('/');
+    const spans=[];
+    spans.push(`<span><a href="${'../'.repeat(parts.length-1)}index.html">Home</a></span>`);
+    for(let i=0;i<parts.length;i++){
+      let label=parts[i].replace('.html','');
+      if(label==='index') continue;
+      spans.push(`<span>${label}</span>`);
+    }
+    bc.innerHTML=spans.join('');
+  }
+});

--- a/docs/odyssey/whispers/embark.html
+++ b/docs/odyssey/whispers/embark.html
@@ -7,6 +7,8 @@
   <script src='../../main.js' defer></script>
 </head>
 <body>
+<button id='dark-toggle'>☾</button>
+<nav id='breadcrumb'></nav>
 <article>
 
 <h3>Call to Aria</h3>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,1 +1,42 @@
-body{font-family:'Helvetica Neue',sans-serif;background:#f0f0f0;color:#222;margin:2rem;line-height:1.6;}article{max-width:65ch;margin:auto;text-align:center;}h1,h2,h3{font-family:'Georgia',serif;color:#003b30;}a{color:#00584d;text-decoration:none;}a:hover{text-decoration:underline;}#story-tree{display:none;}#nav{position:relative;width:600px;height:600px;margin:2rem auto;}#nav canvas{position:absolute;left:0;top:0;width:100%;height:100%;}#nav a.node{position:absolute;width:8px;height:8px;border-radius:50%;background:#003b30;text-indent:-9999px;}#nav a.node:hover{background:#00584d;}#nav a.node::after{content:attr(data-label);position:absolute;top:-1.5em;left:.5em;font-size:.8rem;background:#f0f0f0;color:#222;padding:2px 4px;border-radius:4px;white-space:nowrap;display:none;}#nav a.node:hover::after{display:block;}
+:root{
+  --bg-light: #f0f0f0;
+  --bg-dark: #1a1a1a;
+  --text-light: #222;
+  --text-dark: #f0f0f0;
+  --link-light: #00584d;
+  --link-dark: #80c0b0;
+  --head-light: #003b30;
+  --head-dark: #8de3d3;
+}
+body{
+  font-family:'Helvetica Neue',sans-serif;
+  margin:2rem;
+  line-height:1.6;
+  background:linear-gradient(var(--bg-light),#d0d0d0);
+  color:var(--text-light);
+}
+.dark body{
+  background:linear-gradient(var(--bg-dark),#333);
+  color:var(--text-dark);
+}
+article{max-width:65ch;margin:auto;text-align:center;}
+h1,h2,h3{font-family:'Georgia',serif;color:var(--head-light);}
+.dark h1,.dark h2,.dark h3{color:var(--head-dark);}
+a{color:var(--link-light);text-decoration:none;}
+.dark a{color:var(--link-dark);}
+a:hover{text-decoration:underline;}
+#story-tree{display:none;}
+#nav{position:relative;width:600px;height:600px;margin:2rem auto;}
+#nav canvas{position:absolute;left:0;top:0;width:100%;height:100%;}
+#nav a.node{position:absolute;width:8px;height:8px;border-radius:50%;background:var(--head-light);text-indent:-9999px;}
+#nav a.node:hover{background:var(--link-light);}
+.dark #nav a.node{background:var(--head-dark);} 
+.dark #nav a.node:hover{background:var(--link-dark);} 
+#nav a.node::after{content:attr(data-label);position:absolute;top:-1.5em;left:.5em;font-size:.8rem;background:var(--bg-light);color:var(--text-light);padding:2px 4px;border-radius:4px;white-space:nowrap;display:none;}
+.dark #nav a.node::after{background:var(--bg-dark);color:var(--text-dark);}
+#nav a.node:hover::after{display:block;}
+#dark-toggle{position:fixed;top:1rem;right:1rem;background:var(--head-light);color:var(--bg-light);border:none;padding:.5rem;border-radius:4px;cursor:pointer;}
+.dark #dark-toggle{background:var(--head-dark);color:var(--bg-dark);}
+#breadcrumb{margin-bottom:1rem;font-size:.9rem;}
+#breadcrumb a{color:inherit;text-decoration:none;}
+#breadcrumb span+span::before{content:' / ';}


### PR DESCRIPTION
## Summary
- style with CSS variables for light and dark palettes
- toggle dark mode and generate breadcrumb trail in JS
- add controls and breadcrumbs to HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858739de348832bb9abe22a3508d694